### PR TITLE
Dynamically determine DNS via getprop net.dns

### DIFF
--- a/ubuntu.sh
+++ b/ubuntu.sh
@@ -29,8 +29,6 @@ if [ "$first" != 1 ];then
 	cd "$folder"
 	echo "decompressing ubuntu image"
 	proot --link2symlink tar -xf ${cur}/${tarball} --exclude='dev'||:
-	echo "fixing nameserver, otherwise it can't connect to the internet"
-	echo "nameserver 1.1.1.1" > etc/resolv.conf
 	cd "$cur"
 fi
 mkdir -p binds
@@ -39,6 +37,18 @@ echo "writing launch script"
 cat > $bin <<- EOM
 #!/bin/bash
 cd \$(dirname \$0)
+## setup resolv.conf
+currentdns="\$(getprop net.dns1)"
+i=1
+
+rm -f $folder/etc/resolv.conf
+
+while [ ! -z "\$currentdns" ]; do
+    echo "nameserver \$currentdns" >> $folder/etc/resolv.conf
+    i=\$((i+1))
+    currentdns=\$(getprop net.dns\${i})
+done
+
 ## unset LD_PRELOAD in case termux-exec is installed
 unset LD_PRELOAD
 command="proot"


### PR DESCRIPTION
Statically specifying cloudflare's server maybe problematic if you have internal DNS with internal hostnames. This PR uses android's getprop feature to create the DNS resolv.conf entry dynamically.

The caveat is that if the DNS server changes while during a session (disconnect, reconnect elsewhere), there might be an issue. Could add a fallback DNS to 1.1.1.1 in those cases?