### PR TITLE
Fix FATAL Kernel too old problem in older android

### DIFF
--- a/ubuntu.sh
+++ b/ubuntu.sh
@@ -42,6 +42,8 @@ cd \$(dirname \$0)
 ## unset LD_PRELOAD in case termux-exec is installed
 unset LD_PRELOAD
 command="proot"
+## uncomment following line to fix FATAL : Kernel too old message
+#command+=" -k 4.14.81"
 command+=" --link2symlink"
 command+=" -0"
 command+=" -r $folder"


### PR DESCRIPTION
Uncommenting line 46 will fix the FATAL : kernel too old message in older android devices.