### PR TITLE
Fixed 404 error

### DIFF
--- a/ubuntu.sh
+++ b/ubuntu.sh
@@ -22,7 +22,7 @@ if [ "$first" != 1 ];then
 		*)
 			echo "unknown architecture"; exit 1 ;;
 		esac
-		wget "https://partner-images.canonical.com/core/disco/current/ubuntu-disco-core-cloudimg-${archurl}-root.tar.gz" -O $tarball
+		wget "https://partner-images.canonical.com/core/bionic/current/ubuntu-bionic-core-cloudimg-${archurl}-root.tar.gz" -O $tarball
 	fi
 	cur=`pwd`
 	mkdir -p "$folder"


### PR DESCRIPTION
In issue #124 the problem was '404 on tar.gz download'. Now I have updated the link to a working one.