### PR TITLE
Fixed and changed download url to Ubuntu 18.04

### DIFF
--- a/ubuntu.sh
+++ b/ubuntu.sh
@@ -22,7 +22,7 @@ if [ "$first" != 1 ];then
 		*)
 			echo "unknown architecture"; exit 1 ;;
 		esac
-		wget "https://partner-images.canonical.com/core/disco/current/ubuntu-disco-core-cloudimg-${archurl}-root.tar.gz" -O $tarball
+		wget "https://partner-images.canonical.com/core/bionic/current/ubuntu-bionic-core-cloudimg-${archurl}-root.tar.gz" -O $tarball
 	fi
 	cur=`pwd`
 	mkdir -p "$folder"


### PR DESCRIPTION
Download URL in script was giving a 404 for armhf, changed url to Ubuntu 18.04, now it works

Has files:
https://partner-images.canonical.com/core/bionic/current/

No files:
https://partner-images.canonical.com/core/disco/current/